### PR TITLE
feat: flexible pod resource entries

### DIFF
--- a/charts/lighthouse/templates/_helpers.tpl
+++ b/charts/lighthouse/templates/_helpers.tpl
@@ -45,3 +45,65 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default "jenkins-controller" .Values.jenkinscontroller.nameOverride -}}
 {{- printf "%s-%s" .Chart.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{- define "webhooks.defaultResources" -}}
+limits:
+  cpu: 100m
+  memory: 512Mi
+requests:
+  cpu: 80m
+  memory: 128Mi
+{{- end }}
+
+{{- define "foghorn.defaultResources" -}}
+limits:
+  cpu: 100m
+  memory: 256Mi
+requests:
+  cpu: 80m
+  memory: 128Mi
+{{- end }}
+
+{{- define "tektoncontroller.defaultResources" -}}
+limits:
+  cpu: 100m
+  memory: 256Mi
+requests:
+  cpu: 80m
+  memory: 128Mi
+{{- end }}
+
+{{- define "jenkinscontroller.defaultResources" -}}
+limits:
+  cpu: 100m
+  memory: 256Mi
+requests:
+  cpu: 80m
+  memory: 128Mi
+{{- end }}
+
+{{- define "keeper.defaultResources" -}}
+limits:
+  cpu: 100m
+  memory: 256Mi
+requests:
+  cpu: 80m
+  memory: 128Mi
+{{- end }}
+
+{{- define "poller.defaultResources" -}}
+limits:
+  cpu: 400m
+  memory: 512Mi
+requests:
+  cpu: 100m
+  memory: 128Mi
+{{- end }}
+
+
+
+
+
+
+

--- a/charts/lighthouse/templates/foghorn-deployment.yaml
+++ b/charts/lighthouse/templates/foghorn-deployment.yaml
@@ -80,8 +80,12 @@ spec:
 {{- end }}
         securityContext:
 {{ toYaml .Values.foghorn.containerSecurityContext | indent 12 }}
+{{- if .Values.foghorn.resources }}
         resources:
 {{ toYaml .Values.foghorn.resources | indent 12 }}
+{{- else }}
+{{ include "foghorn.defaultResources" . | indent 12 }}
+{{- end }}
         volumeMounts:
 {{- if .Values.githubApp.enabled }}
           - name: githubapp-tokens

--- a/charts/lighthouse/templates/jenkins-controller-deployment.yaml
+++ b/charts/lighthouse/templates/jenkins-controller-deployment.yaml
@@ -48,8 +48,12 @@ spec:
           {{- end }}
         securityContext:
           {{- toYaml .Values.jenkinscontroller.containerSecurityContext | nindent 12 }}
+{{- if .Values.tektoncontroller.resources }}
         resources:
-          {{- toYaml .Values.jenkinscontroller.resources | nindent 12 }}
+{{ toYaml .Values.tektoncontroller.resources | indent 12 }}
+{{- else }}
+{{ include "tektoncontroller.defaultResources" . | indent 12 }}
+{{- end }}
         volumeMounts:
           - mountPath: "/var/jenkins"
             name: jenkins-token

--- a/charts/lighthouse/templates/keeper-deployment.yaml
+++ b/charts/lighthouse/templates/keeper-deployment.yaml
@@ -104,8 +104,12 @@ spec:
             optional: true
         securityContext:
 {{ toYaml .Values.keeper.containerSecurityContext | indent 10 }}
+{{- if .Values.keeper.resources }}
         resources:
 {{ toYaml .Values.keeper.resources | indent 10 }}
+{{- else }}
+{{ include "keeper.defaultResources" . | indent 10 }}
+{{- end }}
         volumeMounts:
 {{- if .Values.githubApp.enabled }}
         - name: githubapp-tokens

--- a/charts/lighthouse/templates/poller-deployment.yaml
+++ b/charts/lighthouse/templates/poller-deployment.yaml
@@ -119,8 +119,12 @@ spec:
         - secretRef:
             name: jx-boot-job-env-vars
             optional: true
+{{- if .Values.poller.resources }}
         resources:
 {{ toYaml .Values.poller.resources | indent 10 }}
+{{- else }}
+{{ include "poller.defaultResources" . | indent 10 }}
+{{- end }}
         volumeMounts:
 {{- if .Values.githubApp.enabled }}
         - name: githubapp-tokens

--- a/charts/lighthouse/templates/tekton-controller-deployment.yaml
+++ b/charts/lighthouse/templates/tekton-controller-deployment.yaml
@@ -52,8 +52,12 @@ spec:
             optional: true
         securityContext:
           {{- toYaml .Values.tektoncontroller.containerSecurityContext | nindent 12 }}
+{{- if .Values.tektoncontroller.resources }}
         resources:
-          {{- toYaml .Values.tektoncontroller.resources | nindent 12 }}
+{{ toYaml .Values.tektoncontroller.resources | indent 12 }}
+{{- else }}
+{{ include "tektoncontroller.defaultResources" . | indent 12 }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.tektoncontroller.terminationGracePeriodSeconds }}
       nodeSelector:
         {{- toYaml .Values.tektoncontroller.nodeSelector | nindent 8 }}

--- a/charts/lighthouse/templates/webhooks-deployment.yaml
+++ b/charts/lighthouse/templates/webhooks-deployment.yaml
@@ -123,7 +123,11 @@ spec:
         securityContext:
 {{ toYaml .Values.webhooks.containerSecurityContext | indent 12 }}
         resources:
+{{- if .Values.webhooks.resources }}
 {{ toYaml .Values.webhooks.resources | indent 12 }}
+{{- else }}
+{{ include "webhooks.defaultResources" . | indent 12 }}
+{{- end }}
         volumeMounts:
 {{- if .Values.githubApp.enabled }}
           - name: githubapp-tokens

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -159,17 +159,7 @@ webhooks:
   # Uncomment to set loadBalancerSourceRanges for service
   #  loadBalancerSourceRanges: []
 
-  resources:
-    # webhooks.resources.limits -- Resource limits applied to the webhooks pods
-    limits:
-      cpu: 100m
-      # may require more memory to perform the initial 'git clone' cmd for big repositories
-      memory: 512Mi
-
-    # webhooks.resources.requests -- Resource requests applied to the webhooks pods
-    requests:
-      cpu: 80m
-      memory: 128Mi
+  resources: {}
 
   # webhooks.probe -- Liveness and readiness probes settings
   probe:
@@ -247,16 +237,7 @@ foghorn:
     # foghorn.image.pullPolicy -- Template for computing the foghorn controller docker image pull policy
     pullPolicy: "{{ .Values.image.pullPolicy }}"
 
-  resources:
-    # foghorn.resources.limits -- Resource limits applied to the foghorn pods
-    limits:
-      cpu: 100m
-      memory: 256Mi
-
-    # foghorn.resources.requests -- Resource requests applied to the foghorn pods
-    requests:
-      cpu: 80m
-      memory: 128Mi
+  resources: {}
 
   # foghorn.nodeSelector -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) applied to the foghorn pods
   nodeSelector: {}
@@ -320,16 +301,7 @@ tektoncontroller:
   # tektoncontroller.containerSecurityContext -- [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) applied to the tekton controller containers
   containerSecurityContext: {}
 
-  resources:
-    # tektoncontroller.resources.limits -- Resource limits applied to the tekton controller pods
-    limits:
-      cpu: 100m
-      memory: 256Mi
-
-    # tektoncontroller.resources.requests -- Resource requests applied to the tekton controller pods
-    requests:
-      cpu: 80m
-      memory: 128Mi
+  resources: {}
 
   # tektoncontroller.service -- Service settings for the tekton controller
   service:
@@ -379,16 +351,7 @@ jenkinscontroller:
   # jenkinscontroller.containerSecurityContext -- [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) applied to the jenkins controller containers
   containerSecurityContext: {}
 
-  resources:
-    # jenkinscontroller.resources.limits -- Resource limits applied to the jenkins controller pods
-    limits:
-      cpu: 100m
-      memory: 256Mi
-
-    # jenkinscontroller.resources.requests -- Resource requests applied to the jenkins controller pods
-    requests:
-      cpu: 80m
-      memory: 128Mi
+  resources: {}
 
   # jenkinscontroller.service -- Service settings for the jenkins controller
   service:
@@ -429,16 +392,7 @@ keeper:
     externalPort: 80
     internalPort: 8888
 
-  resources:
-    # keeper.resources.limits -- Resource limits applied to the keeper pods
-    limits:
-      cpu: 400m
-      memory: 512Mi
-
-    # keeper.resources.requests -- Resource requests applied to the keeper pods
-    requests:
-      cpu: 100m
-      memory: 128Mi
+  resources: {}
 
   # keeper.probe -- Liveness and readiness probes settings
   probe:
@@ -522,16 +476,7 @@ poller:
   # poller.requireReleaseSuccess -- Keep polling releases until the most recent commit status is successful
   requireReleaseSuccess: false
 
-  resources:
-    # poller.resources.limits -- Resource limits applied to the poller pods
-    limits:
-      cpu: 400m
-      memory: 512Mi
-
-    # poller.resources.requests -- Resource requests applied to the poller pods
-    requests:
-      cpu: 100m
-      memory: 128Mi
+  resources: {}
 
   # poller.probe -- Liveness and readiness probes settings
   probe:


### PR DESCRIPTION
### Changes
* Introduced `defaultResources` helpers within `_helpers.tpl` to provide default resource requests/limits when not specified by the user
* Applied helpers to `resources` stanzas within each ``*-deployment.yaml`
* Updated the deployments within `values.yaml` to set their respective `.resources` as empty objects by default

### Context
The previous configuration is an anti-pattern, where omitting undesired resource allocations required setting the value as null. e.g.:

```
keeper:
...
  resources:
    limits:
      cpu: null
      memory: 10Gi
    requests:
      cpu: 200m
      memory: 4Gi
...
```
This allows the chart to follow the expected helm override behaviour; in this case:
```
keeper:
...
  resources:
    limits:
      memory: 10Gi
    requests:
      cpu: 200m
      memory: 4Gi
...
```

leaving the predefined current defaults as-is