### PR TITLE
chore: use tini as init process for keeper

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.23
 
-RUN apk add --update --no-cache ca-certificates git \
+RUN apk add --update --no-cache ca-certificates git tini \
     && adduser -D -u 1000 jx
 
 USER 1000
 
 COPY ./bin/keeper /home/jx/
-ENTRYPOINT ["/home/jx/keeper"]
+ENTRYPOINT ["/sbin/tini", "--", "/home/jx/keeper"]


### PR DESCRIPTION
### Changes
* Install `tini` in the keeper Dockerfile and use as init

### Context
Keeper spawns git subprocesses during batch picking (`git fetch` -> `git-upload-pack`).

When git exits, orphaned subprocesses get re-parented to `keeper` itself (PID 1). Keeper doesn't effectively reap them, so they pile up as zombies and may exhaust the PID limit of the underlying node.

`tini` acts as a lightweight init process that handles this issue.